### PR TITLE
ignore postgres directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/postgres


### PR DESCRIPTION
`docker compose up` で起動したときに PostgreSQL のデータを永続化するために作られる `postgres` ディレクトリを git の管理から外すPRです。